### PR TITLE
fix: explicitly add phycoerthrin units and fill value

### DIFF
--- a/content/erddap-dev/datasets.xml
+++ b/content/erddap-dev/datasets.xml
@@ -4881,12 +4881,12 @@ tke:                 Rad    Rad    Rad    Clo</att>
         <dataType>double</dataType>
         <!-- sourceAttributes>
             <att name="_ChunkSizes" type="int">15652</att>
-            <att name="_FillValue" type="double">9.969209968386869E36</att>
-            <att name="units">RFU</att>
         </sourceAttributes -->
         <addAttributes>
             <att name="_ChunkSizes">null</att>
             <att name="long_name">Phycoerythrin Bottom</att>
+            <att name="_FillValue" type="double">9.969209968386869E36</att>
+            <att name="units">RFU</att>
         </addAttributes>
     </dataVariable>
     <dataVariable>
@@ -4895,12 +4895,12 @@ tke:                 Rad    Rad    Rad    Clo</att>
         <dataType>double</dataType>
         <!-- sourceAttributes>
             <att name="_ChunkSizes" type="int">15652</att>
-            <att name="_FillValue" type="double">9.969209968386869E36</att>
-            <att name="units">RFU</att>
         </sourceAttributes -->
         <addAttributes>
             <att name="_ChunkSizes">null</att>
             <att name="long_name">Phycoerythrin Surface</att>
+            <att name="_FillValue" type="double">9.969209968386869E36</att>
+            <att name="units">RFU</att>
         </addAttributes>
     </dataVariable>
     <dataVariable>

--- a/content/erddap/datasets.xml
+++ b/content/erddap/datasets.xml
@@ -4547,6 +4547,8 @@ tke:                 Rad    Rad    Rad    Clo</att>
         <addAttributes>
             <att name="_ChunkSizes">null</att>
             <att name="long_name">Phycoerythrin Bottom</att>
+            <att name="_FillValue" type="double">9.969209968386869E36</att>
+            <att name="units">RFU</att>
         </addAttributes>
     </dataVariable>
     <dataVariable>
@@ -4561,6 +4563,8 @@ tke:                 Rad    Rad    Rad    Clo</att>
         <addAttributes>
             <att name="_ChunkSizes">null</att>
             <att name="long_name">Phycoerythrin Surface</att>
+            <att name="_FillValue" type="double">9.969209968386869E36</att>
+            <att name="units">RFU</att>
         </addAttributes>
     </dataVariable>
     <dataVariable>


### PR DESCRIPTION
Usually erddap picks this up from the file source, and it is there in the file source, but it's just not for phycoerthrin...