### PR TITLE
fix: add timezone to docker-compose to sync on front-end

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '3'
 services:
   erddap: &erddap
     image: axiom/docker-erddap:2.02
+    environment:
+     - TZ=America/New_York
     ports:
       - "127.0.0.1:8080:8080"
     volumes:


### PR DESCRIPTION
This PR adds the timezone to ERDDAP's docker config so that ERDDAP and the buoy-api, and the real-time page of the buoy viewer all have the same timezone.