### PR TITLE
test: try downgrading erddap version to potentially fix API issues

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   erddap: &erddap
-    image: axiom/docker-erddap:2.23-jdk17-openjdk
+    image: axiom/docker-erddap:2.02
     ports:
       - 8080:8080
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   erddap: &erddap
-    image: axiom/docker-erddap:2.23-jdk17-openjdk
+    image: axiom/docker-erddap:2.18
     environment:
      - TZ=America/New_York
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   erddap: &erddap
-    image: axiom/docker-erddap:2.18
+    image: axiom/docker-erddap:2.02
     environment:
      - TZ=America/New_York
     ports:


### PR DESCRIPTION
Try downgrading ERDDAP docker image version. The buoy api recently crashed and it appears that the API does not find the "combined" historical buoy data. I verified that the prod dataset XML has the combined dataset in it and that the data re still actually on the server. I also noticed these generic icons with question marks after the last update to the most recent erddap version: 
<img width="1120" alt="image" src="https://github.com/ridatadiscoverycenter/erddap-docker/assets/24841909/1e4beb31-243b-459e-b714-92d859fac279">
 