### PR TITLE
fix: order of x and y in XML

### DIFF
--- a/content/erddap-dev/datasets.xml
+++ b/content/erddap-dev/datasets.xml
@@ -5822,18 +5822,6 @@ tke:                 Rad    Rad    Rad    Clo</att>
         <att name="summary">Translation from x,y coordinates to latitude and longitude for the "Landsat Satellite Surface Temperature v2" dataset.</att>
     </addAttributes>
     <axisVariable>
-        <sourceName>y</sourceName>
-        <destinationName>Y</destinationName>
-        <!-- sourceAttributes>
-        </sourceAttributes -->
-        <addAttributes>
-            <att name="long_name">Y</att>
-            <att name="source_name">y</att>
-            <!-- <att name="standard_name">latitude</att>
-            <att name="units">degrees_north</att> -->
-        </addAttributes>
-    </axisVariable>
-    <axisVariable>
         <sourceName>x</sourceName>
         <destinationName>X</destinationName>
         <!-- sourceAttributes>
@@ -5843,6 +5831,18 @@ tke:                 Rad    Rad    Rad    Clo</att>
             <att name="source_name">x</att>
             <!-- <att name="standard_name">longitude</att>
             <att name="units">degrees_east</att> -->
+        </addAttributes>
+    </axisVariable>
+    <axisVariable>
+        <sourceName>y</sourceName>
+        <destinationName>Y</destinationName>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">Y</att>
+            <att name="source_name">y</att>
+            <!-- <att name="standard_name">latitude</att>
+            <att name="units">degrees_north</att> -->
         </addAttributes>
     </axisVariable>
     <dataVariable>
@@ -6073,18 +6073,6 @@ tke:                 Rad    Rad    Rad    Clo</att>
         <att name="summary">Translation from x,y coordinates to latitude and longitude for the "Landsat Satellite Surface Temperature v2" dataset.</att>
     </addAttributes>
     <axisVariable>
-        <sourceName>y</sourceName>
-        <destinationName>Y</destinationName>
-        <!-- sourceAttributes>
-        </sourceAttributes -->
-        <addAttributes>
-            <att name="long_name">Y</att>
-            <att name="source_name">y</att>
-            <!-- <att name="standard_name">latitude</att>
-            <att name="units">degrees_north</att> -->
-        </addAttributes>
-    </axisVariable>
-    <axisVariable>
         <sourceName>x</sourceName>
         <destinationName>X</destinationName>
         <!-- sourceAttributes>
@@ -6094,6 +6082,18 @@ tke:                 Rad    Rad    Rad    Clo</att>
             <att name="source_name">x</att>
             <!-- <att name="standard_name">longitude</att>
             <att name="units">degrees_east</att> -->
+        </addAttributes>
+    </axisVariable>
+    <axisVariable>
+        <sourceName>y</sourceName>
+        <destinationName>Y</destinationName>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">Y</att>
+            <att name="source_name">y</att>
+            <!-- <att name="standard_name">latitude</att>
+            <att name="units">degrees_north</att> -->
         </addAttributes>
     </axisVariable>
     <dataVariable>

--- a/content/erddap/datasets.xml
+++ b/content/erddap/datasets.xml
@@ -5457,16 +5457,6 @@ tke:                 Rad    Rad    Rad    Clo</att>
         <att name="summary">Translation from x,y coordinates to latitude and longitude for the "Landsat Satellite Surface Temperature v2" dataset.</att>
     </addAttributes>
     <axisVariable>
-        <sourceName>y</sourceName>
-        <destinationName>Y</destinationName>
-        <addAttributes>
-            <att name="long_name">Y</att>
-            <att name="source_name">y</att>
-            <!-- <att name="standard_name">latitude</att>
-            <att name="units">degrees_north</att> -->
-        </addAttributes>
-    </axisVariable>
-    <axisVariable>
         <sourceName>x</sourceName>
         <destinationName>X</destinationName>
         <addAttributes>
@@ -5474,6 +5464,16 @@ tke:                 Rad    Rad    Rad    Clo</att>
             <att name="source_name">x</att>
             <!-- <att name="standard_name">longitude</att>
             <att name="units">degrees_east</att> -->
+        </addAttributes>
+    </axisVariable>
+    <axisVariable>
+        <sourceName>y</sourceName>
+        <destinationName>Y</destinationName>
+        <addAttributes>
+            <att name="long_name">Y</att>
+            <att name="source_name">y</att>
+            <!-- <att name="standard_name">latitude</att>
+            <att name="units">degrees_north</att> -->
         </addAttributes>
     </axisVariable>
     <dataVariable>
@@ -5664,16 +5664,6 @@ tke:                 Rad    Rad    Rad    Clo</att>
         <att name="summary">Translation from x,y coordinates to latitude and longitude for the "Landsat Satellite Surface Temperature v2" dataset.</att>
     </addAttributes>
     <axisVariable>
-        <sourceName>y</sourceName>
-        <destinationName>Y</destinationName>
-        <addAttributes>
-            <att name="long_name">Y</att>
-            <att name="source_name">y</att>
-            <!-- <att name="standard_name">latitude</att>
-            <att name="units">degrees_north</att> -->
-        </addAttributes>
-    </axisVariable>
-    <axisVariable>
         <sourceName>x</sourceName>
         <destinationName>X</destinationName>
         <addAttributes>
@@ -5681,6 +5671,16 @@ tke:                 Rad    Rad    Rad    Clo</att>
             <att name="source_name">x</att>
             <!-- <att name="standard_name">longitude</att>
             <att name="units">degrees_east</att> -->
+        </addAttributes>
+    </axisVariable>
+    <axisVariable>
+        <sourceName>y</sourceName>
+        <destinationName>Y</destinationName>
+        <addAttributes>
+            <att name="long_name">Y</att>
+            <att name="source_name">y</att>
+            <!-- <att name="standard_name">latitude</att>
+            <att name="units">degrees_north</att> -->
         </addAttributes>
     </axisVariable>
     <dataVariable>


### PR DESCRIPTION
This PR fixes the order of X and Y in the XML file to reflect the update to the scripts that generate the netcdf files: https://github.com/ridatadiscoverycenter/bias-corrected-landsat/pull/6