### PR TITLE
Feat add singularity def

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ This file differs from the production compose in two aspects:
 to `http://localhost:8080` instead of `https://pricaimcit.services.brown.edu`.
 
 To run ERDDAP with real data locally, you'll need to grab the data from
-`pricaimcit.services.brown.edu:/isilon_erddap/buoy_data` and put it
-in a folder called `buoy_data` in the root of this project.
+`pricaimcit.services.brown.edu:/isilon_erddap/erddap_data` and put it
+in a folder called `isilon_erddap` in the root of this project.
 
 ## Running Locally
 
@@ -93,3 +93,47 @@ To costumize ERDDAP's appearance and text, edit the `content/erddap/setup.xml` o
 It's recommended to use the `erddap-dev/setup.xml` and check if your changes are working correctly. (See development workflow above). When everything looks correct, add those changes to `erddap/setup.xml`
 
 [1]: https://hub.docker.com/r/axiom/docker-erddap
+
+## Working with OSOM data
+
+The OSOM dataset is huge (>1.5 TB) and requires some special consideration.
+It is best to work on the `/jobtmp` partition that has a much larger storage capacity for each user. It is similar to `scratch` in that it is for short-term work and will get wiped after 30 days.
+
+- `cd /jobtemp/<user>
+- clone this repo there
+- copy over `isilon_data` from `pricaimcit.services.brown.edu:/isilon_erddap/erddap_data` to `./content/isilon_erddap/'
+- transfer the OSOM files for each year to `./content/isilon_erddap/erddap_data/netcdf/osom_v2`
+- build a Singularity image from the `erddap.def` specification
+    ```
+    singularity build erddap.sif erddap.def
+    ```
+- start the local ERDDAP server using Singularity: 
+    ```
+    singularity run \
+    --bind ./content/erddap-dev:/usr/local/tomcat/content/erddap \
+    --bind ./content/isilon_erddap/erddap_data:/erddapData \
+    --bind ${PWD}/config/web.xml:/usr/local/tomcat/webapps/erddap/WEB-INF/web.xml \
+    erddap.sif
+    ```
+- _in a new terminal_, generate the XML with:
+    ```
+    singularity run --app generate_dataset_xml \
+    --bind ./content/erddap-dev:/usr/local/tomcat/content/erddap \
+    --bind ./isilon_erddap/erddap_data:/erddapData \
+    --bind ${PWD}/config/web.xml:/usr/local/tomcat/webapps/erddap/WEB-INF/web.xml \
+    erddap.sif
+    ```
+    **Note:** use the bound path when telling the `generate_dataset_xml` prompts where to find your files. For example, to find the `.nc` files for osom_v2, the path will be `./erddapData/netcdf/osom_v2`
+- then clean upn the XML manually to match the formats of the original OSOM dataset
+- copy the XML block to the `datasets.xml` file inside the `erddap-dev` dir, noting the dataset ID
+- generate the data structure for erddap, which should then load the new dataset into the local server:
+    ```
+    singularity run --app generate_data_structure \
+    --bind ./content/erddap-dev:/usr/local/tomcat/content/erddap \
+    --bind ./content/isilon_erddap/erddap_data:/erddapData \
+    --bind ${PWD}/config/web.xml:/usr/local/tomcat/webapps/erddap/WEB-INF/web.xml \
+    erddap.sif
+    ```
+
+
+

--- a/content/erddap-dev/datasets.xml
+++ b/content/erddap-dev/datasets.xml
@@ -2681,6 +2681,7 @@ This dataset has both historical data (quality controlled, before
     <metadataFrom>last</metadataFrom>
     <matchAxisNDigits>20</matchAxisNDigits>
     <fileTableInMemory>false</fileTableInMemory>
+    <accessibleViaFiles>false</accessibleViaFiles>
     <!-- sourceAttributes>
         <att name="_NCProperties">version=2,netcdf=4.9.2,hdf5=1.14.2</att>
         <att name="ana_file">ROMS/Functionals/ana_btflux.h</att>
@@ -2728,8 +2729,8 @@ tke:   Rad    Rad    Rad    Clo</att>
         <att name="Conventions">CF-1.10, COARDS, ACDD-1.3</att>
         <att name="cpu">null</att>
         <att name="format">null</att>
-        <att name="infoUrl">???</att>
-        <att name="institution">???</att>
+        <att name="infoUrl">riddc.brown.edu</att>
+        <att name="institution">Rhode Island Data Discovery</att>
         <att name="keywords">beta0.2, component, data, density, earth, Earth Science &gt; Oceans &gt; Ocean Temperature &gt; Potential Temperature, Earth Science &gt; Oceans &gt; Salinity/Density &gt; Salinity, Earth Science &gt; Oceans &gt; Sea Surface Topography &gt; Sea Surface Height, eastward, energy, eta, eta_rho, free, free-surface, height, kinetic, KineticEnergyBottom, KineticEnergySurface, momentum, northward, ocean, ocean_time, oceans, osom, osom-beta0.2-2005, points, potential, practical, rho, rho-points, salinity, SalinityBottom, SalinitySurface, science, sea, sea_surface_height, sea_water_potential_temperature, sea_water_practical_salinity, seawater, surface, SurfaceHeight, temperature, time, topography, VelocityEastwardBottom, VelocityEastwardSurface, VelocityNorthwardBottom, VelocityNorthwardSurface, water, WaterTempBottom, WaterTempSurface, xi, xi_rho</att>
         <att name="keywords_vocabulary">GCMD Science Keywords</att>
         <att name="license">[standard]</att>
@@ -2744,7 +2745,8 @@ salt:  RadNud RadNud RadNud Clo
 tke:   Rad    Rad    Rad    Clo</att>
         <att name="os">null</att>
         <att name="standard_name_vocabulary">CF Standard Name Table v70</att>
-        <att name="summary">OSOM-Beta0.2-2005. Data from a local source.</att>
+        <att name="summary">OSOM-Beta0.2. Beta version of OSOM model data (2005-2022). Data from a local source.</att>
+        <att name="title">OSOM-Beta0.2</att>
     </addAttributes>
     <axisVariable>
         <sourceName>ocean_time</sourceName>

--- a/content/erddap-dev/datasets.xml
+++ b/content/erddap-dev/datasets.xml
@@ -5766,7 +5766,7 @@ tke:                 Rad    Rad    Rad    Clo</att>
     <addAttributes>
         <att name="cdm_data_type">Grid</att>
         <att name="Conventions">COARDS, CF-1.6, ACDD-1.3</att>
-        <att name="institution">United States Geolocical Survey</att>
+        <att name="institution">United States Geological Survey</att>
         <att name="infoUrl">https://earthexplorer.usgs.gov</att>
         <att name="publisher_name">Rhode Island Data Discovery</att>
         <att name="publisher_url">riddc.brown.edu</att>

--- a/content/erddap-dev/datasets.xml
+++ b/content/erddap-dev/datasets.xml
@@ -2670,6 +2670,342 @@ This dataset has both historical data (quality controlled, before
     </dataVariable>
 </dataset>
 
+<!-- TJD added 2-25-25 -->
+<dataset type="EDDGridFromNcFiles" datasetID="osom_v2_9429_72b1_b541" active="true">
+    <reloadEveryNMinutes>10080</reloadEveryNMinutes>
+    <updateEveryNMillis>10000</updateEveryNMillis>
+    <fileDir>/erddapData/netcdf/osom_v2/</fileDir>
+    <fileNameRegex>.*\.nc</fileNameRegex>
+    <recursive>true</recursive>
+    <pathRegex>.*</pathRegex>
+    <metadataFrom>last</metadataFrom>
+    <matchAxisNDigits>20</matchAxisNDigits>
+    <fileTableInMemory>false</fileTableInMemory>
+    <!-- sourceAttributes>
+        <att name="_NCProperties">version=2,netcdf=4.9.2,hdf5=1.14.2</att>
+        <att name="ana_file">ROMS/Functionals/ana_btflux.h</att>
+        <att name="bry_file">ROMS_forcing_files/openbound/bry_osom_cosine_hab_monthly-nuts_grid4_mod10_15level_smooth_2005.nc</att>
+        <att name="code_dir">/oscar/data/epscor/OSOM/opt/ROMS_Cosine_Sed</att>
+        <att name="compiler_command">/oscar/runtime/software/hpcx-mpi/4.1.5rc2/hpcx-ompi/bin/mpif90</att>
+        <att name="compiler_flags">-frepack-arrays -fallow-argument-mismatch -fallow-invalid-boz -O3 -ffast-math -ffree-form -ffree-line-length-none -ffree-form -ffree-line-length-none -ffree-for</att>
+        <att name="compiler_system">gfortran</att>
+        <att name="Conventions">CF-1.4</att>
+        <att name="CPP_options">osom_ramptides, ADD_FSOBC, ADD_M2OBC, ANA_BSFLUX, ANA_BTFLUX, ASSUMED_SHAPE, BULK_FLUXES, CURVGRID, DEFLATE, DIFF_GRID, DJ_GRADPS, DOUBLE_PRECISION, EMINUSP, GLS_MIXING, HDF5, LONGWAVE_OUT, MASKING, MIX_GEO_TS, MIX_S_UV, MPI, NONLINEAR, NONLIN_EOS, NO_WRITE_GRID, PERFECT_RESTART, POWER_LAW, PROFILE, K_GSCHEME, RADIATION_2D, RAMP_TIDES, !RST_SINGLE, SALINITY, SOLAR_SOURCE, SOLVE3D, SSH_TIDES, STATIONS, TS_MPDATA, TS_DIF2, UV_ADV, UV_COR, UV_U3HADVECTION, UV_C4VADVECTION, UV_LOGDRAG, UV_TIDES, UV_VIS2, VAR_RHO_2D, VISC_GRID</att>
+        <att name="cpu">x86_64</att>
+        <att name="file">/oscar/data/epscor/OSOM/output/OSOM_v2/2005/ocean_his_0001.nc</att>
+        <att name="format">netCDF-4/HDF5 file</att>
+        <att name="frc_file_01">ROMS_forcing_files/tidal/osom_grid4_mindep_smlp_mod10_tidalforcing_2005.nc</att>
+        <att name="frc_file_02">ROMS_forcing_files/met/frc_NAM_wind_fields_OSOM_2005_ref-2005-01-01.nc</att>
+        <att name="frc_file_03">ROMS_forcing_files/met/frc_bulk8_point_osom_2005_ref-2005-01-01_localswrad.nc</att>
+        <att name="grd_file">ROMS_forcing_files/grid/osom_grid4_mindep_smlp_mod10.nc</att>
+        <att name="header_dir">/oscar/data/epscor/OSOM/work/OSOM_v2</att>
+        <att name="header_file">osom_ramptides.h</att>
+        <att name="his_base">/oscar/data/epscor/OSOM/output/OSOM_v2/2005/ocean_his</att>
+        <att name="history">ROMS/TOMS, Version 3.7, Tuesday - September 17, 2024 -  1:52:51 PM</att>
+        <att name="ini_file">ROMS_forcing_files/init/osom_grid4_mindep_smlp_mod10_ini_hydro_2005.nc</att>
+        <att name="NLM_LBC">
+EDGE:  WEST   SOUTH  EAST   NORTH  
+zeta:  Cha    Cha    Cha    Clo    
+ubar:  Fla    Fla    Fla    Clo    
+vbar:  Fla    Fla    Fla    Clo    
+u:     RadNud RadNud RadNud Clo    
+v:     RadNud RadNud RadNud Clo    
+temp:  RadNud RadNud RadNud Clo    
+salt:  RadNud RadNud RadNud Clo    
+tke:   Rad    Rad    Rad    Clo</att>
+        <att name="os">Linux</att>
+        <att name="rst_file">/oscar/data/epscor/OSOM/output/OSOM_v2/2005/ocean_rst.nc</att>
+        <att name="spos_file">ROMS_forcing_files/input_files/stations_osom_cosine_apr2024_optics.in</att>
+        <att name="sta_file">/oscar/data/epscor/OSOM/output/OSOM_v2/2005/ocean_sta.nc</att>
+        <att name="svn_url">https://www.myroms.org/svn/src/trunk</att>
+        <att name="tiling">016x016</att>
+        <att name="title">OSOM-Beta0.2-2005</att>
+        <att name="type">ROMS/TOMS history file</att>
+    </sourceAttributes -->
+    <addAttributes>
+        <att name="_NCProperties">null</att>
+        <att name="cdm_data_type">Grid</att>
+        <att name="Conventions">CF-1.10, COARDS, ACDD-1.3</att>
+        <att name="cpu">null</att>
+        <att name="format">null</att>
+        <att name="infoUrl">???</att>
+        <att name="institution">???</att>
+        <att name="keywords">beta0.2, component, data, density, earth, Earth Science &gt; Oceans &gt; Ocean Temperature &gt; Potential Temperature, Earth Science &gt; Oceans &gt; Salinity/Density &gt; Salinity, Earth Science &gt; Oceans &gt; Sea Surface Topography &gt; Sea Surface Height, eastward, energy, eta, eta_rho, free, free-surface, height, kinetic, KineticEnergyBottom, KineticEnergySurface, momentum, northward, ocean, ocean_time, oceans, osom, osom-beta0.2-2005, points, potential, practical, rho, rho-points, salinity, SalinityBottom, SalinitySurface, science, sea, sea_surface_height, sea_water_potential_temperature, sea_water_practical_salinity, seawater, surface, SurfaceHeight, temperature, time, topography, VelocityEastwardBottom, VelocityEastwardSurface, VelocityNorthwardBottom, VelocityNorthwardSurface, water, WaterTempBottom, WaterTempSurface, xi, xi_rho</att>
+        <att name="keywords_vocabulary">GCMD Science Keywords</att>
+        <att name="license">[standard]</att>
+        <att name="NLM_LBC">EDGE:  WEST   SOUTH  EAST   NORTH  
+zeta:  Cha    Cha    Cha    Clo    
+ubar:  Fla    Fla    Fla    Clo    
+vbar:  Fla    Fla    Fla    Clo    
+u:     RadNud RadNud RadNud Clo    
+v:     RadNud RadNud RadNud Clo    
+temp:  RadNud RadNud RadNud Clo    
+salt:  RadNud RadNud RadNud Clo    
+tke:   Rad    Rad    Rad    Clo</att>
+        <att name="os">null</att>
+        <att name="standard_name_vocabulary">CF Standard Name Table v70</att>
+        <att name="summary">OSOM-Beta0.2-2005. Data from a local source.</att>
+    </addAttributes>
+    <axisVariable>
+        <sourceName>ocean_time</sourceName>
+        <destinationName>time</destinationName>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uint">17</att>
+            <att name="calendar">gregorian</att>
+            <att name="field">time, scalar, series</att>
+            <att name="long_name">time since initialization</att>
+            <att name="units">seconds since 1970-01-01 00:00:00</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="source_name">ocean_time</att>
+            <att name="standard_name">time</att>
+            <att name="units">seconds since 1970-01-01T00:00:00Z</att>
+        </addAttributes>
+    </axisVariable>
+    <axisVariable>
+        <sourceName>eta_rho</sourceName>
+        <destinationName>eta_rho</destinationName>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">eta rho</att>
+        </addAttributes>
+    </axisVariable>
+    <axisVariable>
+        <sourceName>xi_rho</sourceName>
+        <destinationName>xi_rho</destinationName>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">xi rho</att>
+        </addAttributes>
+    </axisVariable>
+    <dataVariable>
+        <sourceName>SalinityBottom</sourceName>
+        <destinationName>SalinityBottom</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uintList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">salinity, scalar, series</att>
+            <att name="long_name">salinity</att>
+            <att name="time">ocean_time</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">37.0</att>
+            <att name="colorBarMinimum" type="double">32.0</att>
+            <att name="coordinates">null</att>
+            <att name="standard_name">sea_water_practical_salinity</att>
+            <att name="units">PSU</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>SalinitySurface</sourceName>
+        <destinationName>SalinitySurface</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uintList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">salinity, scalar, series</att>
+            <att name="long_name">salinity</att>
+            <att name="time">ocean_time</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">37.0</att>
+            <att name="colorBarMinimum" type="double">32.0</att>
+            <att name="coordinates">null</att>
+            <att name="standard_name">sea_water_practical_salinity</att>
+            <att name="units">PSU</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>WaterTempBottom</sourceName>
+        <destinationName>WaterTempBottom</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uintList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">temperature, scalar, series</att>
+            <att name="long_name">potential temperature</att>
+            <att name="time">ocean_time</att>
+            <att name="units">Celsius</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">32.0</att>
+            <att name="colorBarMinimum" type="double">0.0</att>
+            <att name="coordinates">null</att>
+            <att name="standard_name">sea_water_potential_temperature</att>
+            <att name="units">degree_C</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>WaterTempSurface</sourceName>
+        <destinationName>WaterTempSurface</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uintList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">temperature, scalar, series</att>
+            <att name="long_name">potential temperature</att>
+            <att name="time">ocean_time</att>
+            <att name="units">Celsius</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">32.0</att>
+            <att name="colorBarMinimum" type="double">0.0</att>
+            <att name="coordinates">null</att>
+            <att name="standard_name">sea_water_potential_temperature</att>
+            <att name="units">degree_C</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>SurfaceHeight</sourceName>
+        <destinationName>SurfaceHeight</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uintList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho ocean_time</att>
+            <att name="field">free-surface, scalar, series</att>
+            <att name="long_name">free-surface</att>
+            <att name="time">ocean_time</att>
+            <att name="units">meter</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">2.0</att>
+            <att name="colorBarMinimum" type="double">-2.0</att>
+            <att name="coordinates">null</att>
+            <att name="standard_name">sea_surface_height</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>VelocityEastwardBottom</sourceName>
+        <destinationName>VelocityEastwardBottom</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uintList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">u_eastward, scalar, series</att>
+            <att name="long_name">eastward momentum component at RHO-points</att>
+            <att name="time">ocean_time</att>
+            <att name="units">meter second-1</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">0.3</att>
+            <att name="colorBarMinimum" type="double">-0.3</att>
+            <att name="coordinates">null</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>VelocityEastwardSurface</sourceName>
+        <destinationName>VelocityEastwardSurface</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uintList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">u_eastward, scalar, series</att>
+            <att name="long_name">eastward momentum component at RHO-points</att>
+            <att name="time">ocean_time</att>
+            <att name="units">meter second-1</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">0.3</att>
+            <att name="colorBarMinimum" type="double">-0.3</att>
+            <att name="coordinates">null</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>VelocityNorthwardBottom</sourceName>
+        <destinationName>VelocityNorthwardBottom</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uintList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">v_northward, scalar, series</att>
+            <att name="long_name">northward momentum component at RHO-points</att>
+            <att name="time">ocean_time</att>
+            <att name="units">meter second-1</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">0.3</att>
+            <att name="colorBarMinimum" type="double">-0.3</att>
+            <att name="coordinates">null</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>VelocityNorthwardSurface</sourceName>
+        <destinationName>VelocityNorthwardSurface</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uintList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">v_northward, scalar, series</att>
+            <att name="long_name">northward momentum component at RHO-points</att>
+            <att name="time">ocean_time</att>
+            <att name="units">meter second-1</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">0.3</att>
+            <att name="colorBarMinimum" type="double">-0.3</att>
+            <att name="coordinates">null</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>KineticEnergyBottom</sourceName>
+        <destinationName>KineticEnergyBottom</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uintList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">ke, scalar, series</att>
+            <att name="long_name">kinetic energy at RHO-points</att>
+            <att name="time">ocean_time</att>
+            <att name="units">J kg-1</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="coordinates">null</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>KineticEnergySurface</sourceName>
+        <destinationName>KineticEnergySurface</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uintList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">ke, scalar, series</att>
+            <att name="long_name">kinetic energy at RHO-points</att>
+            <att name="time">ocean_time</att>
+            <att name="units">J kg-1</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="coordinates">null</att>
+        </addAttributes>
+    </dataVariable>
+</dataset>
+
 <!-- MCM added -->
 <!-- NOTE! The source for model_data_57db_4a85_81d9 has nGridVariables=5,
   but this dataset will only serve 4 because the others use different dimensions. -->

--- a/content/erddap/datasets.xml
+++ b/content/erddap/datasets.xml
@@ -2685,6 +2685,659 @@ tke:                 Rad    Rad    Rad    Clo</att>
     </dataVariable>
 </dataset>
 
+<!-- TJD added 2-25-25 -->
+<dataset type="EDDGridFromNcFiles" datasetID="osom_v2_9429_72b1_b541" active="true">
+    <reloadEveryNMinutes>10080</reloadEveryNMinutes>
+    <updateEveryNMillis>10000</updateEveryNMillis>
+    <fileDir>/erddapData/netcdf/osom_v2/</fileDir>
+    <fileNameRegex>.*\.nc</fileNameRegex>
+    <recursive>true</recursive>
+    <pathRegex>.*</pathRegex>
+    <metadataFrom>last</metadataFrom>
+    <matchAxisNDigits>20</matchAxisNDigits>
+    <fileTableInMemory>false</fileTableInMemory>
+    <accessibleViaFiles>false</accessibleViaFiles>
+    <!-- sourceAttributes>
+        <att name="_NCProperties">version=2,netcdf=4.9.2,hdf5=1.14.2</att>
+        <att name="ana_file">ROMS/Functionals/ana_btflux.h</att>
+        <att name="bry_file">ROMS_forcing_files/openbound/bry_osom_cosine_hab_monthly-nuts_grid4_mod10_15level_smooth_2005.nc</att>
+        <att name="code_dir">/oscar/data/epscor/OSOM/opt/ROMS_Cosine_Sed</att>
+        <att name="compiler_command">/oscar/runtime/software/hpcx-mpi/4.1.5rc2/hpcx-ompi/bin/mpif90</att>
+        <att name="compiler_flags">-frepack-arrays -fallow-argument-mismatch -fallow-invalid-boz -O3 -ffast-math -ffree-form -ffree-line-length-none -ffree-form -ffree-line-length-none -ffree-for</att>
+        <att name="compiler_system">gfortran</att>
+        <att name="Conventions">CF-1.4</att>
+        <att name="CPP_options">osom_ramptides, ADD_FSOBC, ADD_M2OBC, ANA_BSFLUX, ANA_BTFLUX, ASSUMED_SHAPE, BULK_FLUXES, CURVGRID, DEFLATE, DIFF_GRID, DJ_GRADPS, DOUBLE_PRECISION, EMINUSP, GLS_MIXING, HDF5, LONGWAVE_OUT, MASKING, MIX_GEO_TS, MIX_S_UV, MPI, NONLINEAR, NONLIN_EOS, NO_WRITE_GRID, PERFECT_RESTART, POWER_LAW, PROFILE, K_GSCHEME, RADIATION_2D, RAMP_TIDES, !RST_SINGLE, SALINITY, SOLAR_SOURCE, SOLVE3D, SSH_TIDES, STATIONS, TS_MPDATA, TS_DIF2, UV_ADV, UV_COR, UV_U3HADVECTION, UV_C4VADVECTION, UV_LOGDRAG, UV_TIDES, UV_VIS2, VAR_RHO_2D, VISC_GRID</att>
+        <att name="cpu">x86_64</att>
+        <att name="file">/oscar/data/epscor/OSOM/output/OSOM_v2/2005/ocean_his_0001.nc</att>
+        <att name="format">netCDF-4/HDF5 file</att>
+        <att name="frc_file_01">ROMS_forcing_files/tidal/osom_grid4_mindep_smlp_mod10_tidalforcing_2005.nc</att>
+        <att name="frc_file_02">ROMS_forcing_files/met/frc_NAM_wind_fields_OSOM_2005_ref-2005-01-01.nc</att>
+        <att name="frc_file_03">ROMS_forcing_files/met/frc_bulk8_point_osom_2005_ref-2005-01-01_localswrad.nc</att>
+        <att name="grd_file">ROMS_forcing_files/grid/osom_grid4_mindep_smlp_mod10.nc</att>
+        <att name="header_dir">/oscar/data/epscor/OSOM/work/OSOM_v2</att>
+        <att name="header_file">osom_ramptides.h</att>
+        <att name="his_base">/oscar/data/epscor/OSOM/output/OSOM_v2/2005/ocean_his</att>
+        <att name="history">ROMS/TOMS, Version 3.7, Tuesday - September 17, 2024 -  1:52:51 PM</att>
+        <att name="ini_file">ROMS_forcing_files/init/osom_grid4_mindep_smlp_mod10_ini_hydro_2005.nc</att>
+        <att name="NLM_LBC">
+EDGE:  WEST   SOUTH  EAST   NORTH  
+zeta:  Cha    Cha    Cha    Clo    
+ubar:  Fla    Fla    Fla    Clo    
+vbar:  Fla    Fla    Fla    Clo    
+u:     RadNud RadNud RadNud Clo    
+v:     RadNud RadNud RadNud Clo    
+temp:  RadNud RadNud RadNud Clo    
+salt:  RadNud RadNud RadNud Clo    
+tke:   Rad    Rad    Rad    Clo</att>
+        <att name="os">Linux</att>
+        <att name="rst_file">/oscar/data/epscor/OSOM/output/OSOM_v2/2005/ocean_rst.nc</att>
+        <att name="spos_file">ROMS_forcing_files/input_files/stations_osom_cosine_apr2024_optics.in</att>
+        <att name="sta_file">/oscar/data/epscor/OSOM/output/OSOM_v2/2005/ocean_sta.nc</att>
+        <att name="svn_url">https://www.myroms.org/svn/src/trunk</att>
+        <att name="tiling">016x016</att>
+        <att name="title">OSOM-Beta0.2-2005</att>
+        <att name="type">ROMS/TOMS history file</att>
+    </sourceAttributes -->
+    <addAttributes>
+        <att name="_NCProperties">null</att>
+        <att name="cdm_data_type">Grid</att>
+        <att name="Conventions">CF-1.10, COARDS, ACDD-1.3</att>
+        <att name="cpu">null</att>
+        <att name="format">null</att>
+        <att name="infoUrl">riddc.brown.edu</att>
+        <att name="institution">Rhode Island Data Discovery</att>
+        <att name="keywords">beta0.2, component, data, density, earth, Earth Science &gt; Oceans &gt; Ocean Temperature &gt; Potential Temperature, Earth Science &gt; Oceans &gt; Salinity/Density &gt; Salinity, Earth Science &gt; Oceans &gt; Sea Surface Topography &gt; Sea Surface Height, eastward, energy, eta, eta_rho, free, free-surface, height, kinetic, KineticEnergyBottom, KineticEnergySurface, momentum, northward, ocean, ocean_time, oceans, osom, osom-beta0.2-2005, points, potential, practical, rho, rho-points, salinity, SalinityBottom, SalinitySurface, science, sea, sea_surface_height, sea_water_potential_temperature, sea_water_practical_salinity, seawater, surface, SurfaceHeight, temperature, time, topography, VelocityEastwardBottom, VelocityEastwardSurface, VelocityNorthwardBottom, VelocityNorthwardSurface, water, WaterTempBottom, WaterTempSurface, xi, xi_rho</att>
+        <att name="keywords_vocabulary">GCMD Science Keywords</att>
+        <att name="license">[standard]</att>
+        <att name="NLM_LBC">EDGE:  WEST   SOUTH  EAST   NORTH  
+zeta:  Cha    Cha    Cha    Clo    
+ubar:  Fla    Fla    Fla    Clo    
+vbar:  Fla    Fla    Fla    Clo    
+u:     RadNud RadNud RadNud Clo    
+v:     RadNud RadNud RadNud Clo    
+temp:  RadNud RadNud RadNud Clo    
+salt:  RadNud RadNud RadNud Clo    
+tke:   Rad    Rad    Rad    Clo</att>
+        <att name="os">null</att>
+        <att name="standard_name_vocabulary">CF Standard Name Table v70</att>
+        <att name="summary">OSOM-Beta0.2. Beta version of OSOM model data (2005-2022). Data from a local source.</att>
+        <att name="title">OSOM-Beta0.2</att>
+    </addAttributes>
+    <axisVariable>
+        <sourceName>ocean_time</sourceName>
+        <destinationName>time</destinationName>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uint">17</att>
+            <att name="calendar">gregorian</att>
+            <att name="field">time, scalar, series</att>
+            <att name="long_name">time since initialization</att>
+            <att name="units">seconds since 1970-01-01 00:00:00</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="source_name">ocean_time</att>
+            <att name="standard_name">time</att>
+            <att name="units">seconds since 1970-01-01T00:00:00Z</att>
+        </addAttributes>
+    </axisVariable>
+    <axisVariable>
+        <sourceName>eta_rho</sourceName>
+        <destinationName>eta_rho</destinationName>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">eta rho</att>
+        </addAttributes>
+    </axisVariable>
+    <axisVariable>
+        <sourceName>xi_rho</sourceName>
+        <destinationName>xi_rho</destinationName>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">xi rho</att>
+        </addAttributes>
+    </axisVariable>
+    <dataVariable>
+        <sourceName>SalinityBottom</sourceName>
+        <destinationName>SalinityBottom</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uintList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">salinity, scalar, series</att>
+            <att name="long_name">salinity</att>
+            <att name="time">ocean_time</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">37.0</att>
+            <att name="colorBarMinimum" type="double">32.0</att>
+            <att name="coordinates">null</att>
+            <att name="standard_name">sea_water_practical_salinity</att>
+            <att name="units">PSU</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>SalinitySurface</sourceName>
+        <destinationName>SalinitySurface</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uintList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">salinity, scalar, series</att>
+            <att name="long_name">salinity</att>
+            <att name="time">ocean_time</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">37.0</att>
+            <att name="colorBarMinimum" type="double">32.0</att>
+            <att name="coordinates">null</att>
+            <att name="standard_name">sea_water_practical_salinity</att>
+            <att name="units">PSU</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>WaterTempBottom</sourceName>
+        <destinationName>WaterTempBottom</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uintList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">temperature, scalar, series</att>
+            <att name="long_name">potential temperature</att>
+            <att name="time">ocean_time</att>
+            <att name="units">Celsius</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">32.0</att>
+            <att name="colorBarMinimum" type="double">0.0</att>
+            <att name="coordinates">null</att>
+            <att name="standard_name">sea_water_potential_temperature</att>
+            <att name="units">degree_C</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>WaterTempSurface</sourceName>
+        <destinationName>WaterTempSurface</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uintList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">temperature, scalar, series</att>
+            <att name="long_name">potential temperature</att>
+            <att name="time">ocean_time</att>
+            <att name="units">Celsius</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">32.0</att>
+            <att name="colorBarMinimum" type="double">0.0</att>
+            <att name="coordinates">null</att>
+            <att name="standard_name">sea_water_potential_temperature</att>
+            <att name="units">degree_C</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>SurfaceHeight</sourceName>
+        <destinationName>SurfaceHeight</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uintList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho ocean_time</att>
+            <att name="field">free-surface, scalar, series</att>
+            <att name="long_name">free-surface</att>
+            <att name="time">ocean_time</att>
+            <att name="units">meter</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">2.0</att>
+            <att name="colorBarMinimum" type="double">-2.0</att>
+            <att name="coordinates">null</att>
+            <att name="standard_name">sea_surface_height</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>VelocityEastwardBottom</sourceName>
+        <destinationName>VelocityEastwardBottom</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uintList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">u_eastward, scalar, series</att>
+            <att name="long_name">eastward momentum component at RHO-points</att>
+            <att name="time">ocean_time</att>
+            <att name="units">meter second-1</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">0.3</att>
+            <att name="colorBarMinimum" type="double">-0.3</att>
+            <att name="coordinates">null</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>VelocityEastwardSurface</sourceName>
+        <destinationName>VelocityEastwardSurface</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uintList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">u_eastward, scalar, series</att>
+            <att name="long_name">eastward momentum component at RHO-points</att>
+            <att name="time">ocean_time</att>
+            <att name="units">meter second-1</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">0.3</att>
+            <att name="colorBarMinimum" type="double">-0.3</att>
+            <att name="coordinates">null</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>VelocityNorthwardBottom</sourceName>
+        <destinationName>VelocityNorthwardBottom</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uintList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">v_northward, scalar, series</att>
+            <att name="long_name">northward momentum component at RHO-points</att>
+            <att name="time">ocean_time</att>
+            <att name="units">meter second-1</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">0.3</att>
+            <att name="colorBarMinimum" type="double">-0.3</att>
+            <att name="coordinates">null</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>VelocityNorthwardSurface</sourceName>
+        <destinationName>VelocityNorthwardSurface</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uintList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">v_northward, scalar, series</att>
+            <att name="long_name">northward momentum component at RHO-points</att>
+            <att name="time">ocean_time</att>
+            <att name="units">meter second-1</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">0.3</att>
+            <att name="colorBarMinimum" type="double">-0.3</att>
+            <att name="coordinates">null</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>KineticEnergyBottom</sourceName>
+        <destinationName>KineticEnergyBottom</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uintList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">ke, scalar, series</att>
+            <att name="long_name">kinetic energy at RHO-points</att>
+            <att name="time">ocean_time</att>
+            <att name="units">J kg-1</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="coordinates">null</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>KineticEnergySurface</sourceName>
+        <destinationName>KineticEnergySurface</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="uintList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">ke, scalar, series</att>
+            <att name="long_name">kinetic energy at RHO-points</att>
+            <att name="time">ocean_time</att>
+            <att name="units">J kg-1</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="coordinates">null</att>
+        </addAttributes>
+    </dataVariable>
+</dataset>
+
+<!-- MCM added -->
+<!-- NOTE! The source for model_data_57db_4a85_81d9 has nGridVariables=5,
+  but this dataset will only serve 4 because the others use different dimensions. -->
+<dataset type="EDDGridFromNcFiles" datasetID="model_data_57db_4a85_81d9" active="true">
+    <reloadEveryNMinutes>10080</reloadEveryNMinutes>
+    <updateEveryNMillis>10000</updateEveryNMillis>
+    <fileDir>/erddapData/netcdf/model_data/</fileDir>
+    <fileNameRegex>[0-9]+_surf_his\.nc</fileNameRegex>
+    <recursive>true</recursive>
+    <pathRegex>.*</pathRegex>
+    <metadataFrom>last</metadataFrom>
+    <matchAxisNDigits>20</matchAxisNDigits>
+    <fileTableInMemory>false</fileTableInMemory>
+    <accessibleViaFiles>false</accessibleViaFiles>
+    <!-- sourceAttributes>
+        <att name="ana_file">ROMS/Functionals/ana_btflux.h, ROMS/Functionals/ana_stflux.h</att>
+        <att name="bio_file">ROMS/Nonlinear/Biology/bio_UMAINE15.h</att>
+        <att name="bpar_file">bio_UMAINE15_v5.in</att>
+        <att name="bry_file">bry_osom_cosine_monthly_grid4_mindep_smlp_mod7_2018.nc</att>
+        <att name="code_dir">/gpfs_home/dullman1/ROMS/trunk</att>
+        <att name="compiler_command">/gpfs/runtime/opt/mpi/openmpi_2.0.3_intel/bin/mpif90</att>
+        <att name="compiler_flags">-heap-arrays -fp-model precise -ip -O3 -free -free</att>
+        <att name="compiler_system">ifort</att>
+        <att name="Conventions">CF-1.4</att>
+        <att name="CPP_options">epscor_umaine15, ADD_FSOBC, ADD_M2OBC, ANA_BPFLUX, ANA_BSFLUX, ANA_BTFLUX, ANA_SPFLUX, ASSUMED_SHAPE, BIO_UMAINE15, BULK_FLUXES, CARBON, CURVGRID, DEFLATE, DIFF_GRID, DJ_GRADPS, DOUBLE_PRECISION, EMINUSP, GLS_MIXING, HDF5, LONGWAVE_OUT, MASKING, MIX_GEO_TS, MIX_S_UV, MPI, NONLINEAR, NONLIN_EOS, NO_WRITE_GRID, OXYGEN, SINK_OP2, TALK_NONCO PERFECT_RESTART, POWER_LAW, PROFILE, K_GSCHEME, RADIATION_2D, RAMP_TIDES, !RST_SINGLE, SALINITY, SOLVE3D, SSH_TIDES, STATIONS, TS_A4HADVECTION, TS_A4VADVECTION, TS_DIF2, UV_ADV, UV_COR, UV_U3HADVECTION, UV_C4VADVECTION, UV_LOGDRAG, UV_TIDES, UV_VIS2, VAR_RHO_2D, VISC_GRID</att>
+        <att name="cpu">x86_64</att>
+        <att name="file">/users/dullman1/data/dullman1/EPSCOR/2018_run1_NAM/ocean_his_0001.nc</att>
+        <att name="format">netCDF-4/HDF5 file</att>
+        <att name="frc_file_01">osom_grid4_mindep_smlp_mod7_tidalforcing_2018.nc</att>
+        <att name="frc_file_02">frc_NAM_wind_fields_osom_2018.nc</att>
+        <att name="frc_file_03">frc_bulk8_point_osom_2018.nc</att>
+        <att name="grd_file">osom_grid4_mindep_smlp_mod7.nc</att>
+        <att name="header_dir">/users/dullman1/projects/EPSCoR</att>
+        <att name="header_file">epscor_umaine15.h</att>
+        <att name="his_base">/users/dullman1/data/dullman1/EPSCOR/2018_run1_NAM/ocean_his</att>
+        <att name="history">ROMS/TOMS, Version 3.7, Monday - February 24, 2020 - 10:50:00 AM</att>
+        <att name="ini_file">osom_cosine_grid4_mindep_smlp_mod7_ini_hydro_2018.nc</att>
+        <att name="NLM_LBC">
+EDGE:                WEST   SOUTH  EAST   NORTH
+zeta:                Cha    Cha    Cha    Clo
+ubar:                Fla    Fla    Fla    Clo
+vbar:                Fla    Fla    Fla    Clo
+u:                   RadNud RadNud RadNud Clo
+v:                   RadNud RadNud RadNud Clo
+temp:                RadNud RadNud RadNud Clo
+salt:                RadNud RadNud RadNud Clo
+NO3:                 RadNud RadNud RadNud Clo
+NH4:                 RadNud RadNud RadNud Clo
+SiOH4:               RadNud RadNud RadNud Clo
+smallphytoplankton:  Rad    Rad    Rad    Clo
+diatom:              Rad    Rad    Rad    Clo
+microzooplankton:    Rad    Rad    Rad    Clo
+mesozooplankton:     Rad    Rad    Rad    Clo
+detritus:            Rad    Rad    Rad    Clo
+opal:                Rad    Rad    Rad    Clo
+PO4:                 RadNud RadNud RadNud Clo
+chlorophyll1:        Rad    Rad    Rad    Clo
+chlorophyll2:        Rad    Rad    Rad    Clo
+oxygen:              Rad    Rad    Rad    Clo
+TIC:                 Rad    Rad    Rad    Clo
+alkalinity:          Rad    Rad    Rad    Clo
+tke:                 Rad    Rad    Rad    Clo</att>
+        <att name="os">Linux</att>
+        <att name="rst_file">/users/dullman1/data/dullman1/EPSCOR/2018_run1_NAM/ocean_rst.nc</att>
+        <att name="spos_file">stations_osom_cosine_feb2020.in</att>
+        <att name="sta_file">/users/dullman1/data/dullman1/EPSCOR/2018_run1_NAM/ocean_sta.nc</att>
+        <att name="svn_url">https://www.myroms.org/svn/src/trunk</att>
+        <att name="tiling">016x013</att>
+        <att name="title">OSOM-Beta0.1-2018</att>
+        <att name="type">ROMS/TOMS history file</att>
+    </sourceAttributes -->
+    <addAttributes>
+        <att name="cdm_data_type">Grid</att>
+        <att name="Conventions">CF-1.6, COARDS, ACDD-1.3</att>
+        <att name="cpu">null</att>
+        <att name="format">null</att>
+        <att name="infoUrl">riddc.brown.edu</att>
+        <att name="institution">Rhode Island Data Discovery</att>
+        <att name="keywords">beta0.1, data, density, earth, Earth Science &gt; Oceans &gt; Ocean Temperature &gt; Potential Temperature, Earth Science &gt; Oceans &gt; Salinity/Density &gt; Salinity, eta_rho, ocean, ocean_time, oceans, osom, osom-beta0.1-2018, potential, practical, salinity, SalinityBottom, SalinitySurface, science, sea, sea_water_potential_temperature, sea_water_practical_salinity, seawater, temperature, water, WaterTempBottom, WaterTempSurface, xi_rho</att>
+        <att name="keywords_vocabulary">GCMD Science Keywords</att>
+        <att name="license">[standard]</att>
+        <att name="NLM_LBC">EDGE:                WEST   SOUTH  EAST   NORTH
+zeta:                Cha    Cha    Cha    Clo
+ubar:                Fla    Fla    Fla    Clo
+vbar:                Fla    Fla    Fla    Clo
+u:                   RadNud RadNud RadNud Clo
+v:                   RadNud RadNud RadNud Clo
+temp:                RadNud RadNud RadNud Clo
+salt:                RadNud RadNud RadNud Clo
+NO3:                 RadNud RadNud RadNud Clo
+NH4:                 RadNud RadNud RadNud Clo
+SiOH4:               RadNud RadNud RadNud Clo
+smallphytoplankton:  Rad    Rad    Rad    Clo
+diatom:              Rad    Rad    Rad    Clo
+microzooplankton:    Rad    Rad    Rad    Clo
+mesozooplankton:     Rad    Rad    Rad    Clo
+detritus:            Rad    Rad    Rad    Clo
+opal:                Rad    Rad    Rad    Clo
+PO4:                 RadNud RadNud RadNud Clo
+chlorophyll1:        Rad    Rad    Rad    Clo
+chlorophyll2:        Rad    Rad    Rad    Clo
+oxygen:              Rad    Rad    Rad    Clo
+TIC:                 Rad    Rad    Rad    Clo
+alkalinity:          Rad    Rad    Rad    Clo
+tke:                 Rad    Rad    Rad    Clo</att>
+        <att name="os">null</att>
+        <att name="standard_name_vocabulary">CF Standard Name Table v55</att>
+        <att name="summary">OSOM-Beta0.1. Beta version of OSOM model data. Data from a local source.</att>
+        <att name="title">OSOM-Beta0.1</att>
+    </addAttributes>
+    <axisVariable>
+        <sourceName>ocean_time</sourceName>
+        <destinationName>time</destinationName>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="int">17</att>
+            <att name="calendar">gregorian</att>
+            <att name="field">time, scalar, series</att>
+            <att name="long_name">time since initialization</att>
+            <att name="units">seconds since 2018-01-01 00:00:00</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="source_name">ocean_time</att>
+            <att name="standard_name">time</att>
+            <att name="units">seconds since 1970-01-01T00:00:00Z</att>
+        </addAttributes>
+    </axisVariable>
+    <axisVariable>
+        <sourceName>eta_rho</sourceName>
+        <destinationName>eta_rho</destinationName>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">eta rho</att>
+        </addAttributes>
+    </axisVariable>
+    <axisVariable>
+        <sourceName>xi_rho</sourceName>
+        <destinationName>xi_rho</destinationName>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">xi rho</att>
+        </addAttributes>
+    </axisVariable>
+    <dataVariable>
+        <sourceName>SalinityBottom</sourceName>
+        <destinationName>SalinityBottom</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="intList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">salinity, scalar, series</att>
+            <att name="long_name">salinity</att>
+            <att name="time">ocean_time</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">37.0</att>
+            <att name="colorBarMinimum" type="double">32.0</att>
+            <att name="coordinates">null</att>
+            <att name="standard_name">sea_water_practical_salinity</att>
+            <att name="units">PSU</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>WaterTempBottom</sourceName>
+        <destinationName>WaterTempBottom</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="intList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">temperature, scalar, series</att>
+            <att name="long_name">potential temperature</att>
+            <att name="time">ocean_time</att>
+            <att name="units">Celsius</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">32.0</att>
+            <att name="colorBarMinimum" type="double">0.0</att>
+            <att name="coordinates">null</att>
+            <att name="standard_name">sea_water_potential_temperature</att>
+            <att name="units">degree_C</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>SalinitySurface</sourceName>
+        <destinationName>SalinitySurface</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="intList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">salinity, scalar, series</att>
+            <att name="long_name">salinity</att>
+            <att name="time">ocean_time</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">37.0</att>
+            <att name="colorBarMinimum" type="double">32.0</att>
+            <att name="coordinates">null</att>
+            <att name="standard_name">sea_water_practical_salinity</att>
+            <att name="units">PSU</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>WaterTempSurface</sourceName>
+        <destinationName>WaterTempSurface</destinationName>
+        <dataType>float</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="intList">1 550 500</att>
+            <att name="_FillValue" type="float">1.0E37</att>
+            <att name="coordinates">lon_rho lat_rho s_rho ocean_time</att>
+            <att name="field">temperature, scalar, series</att>
+            <att name="long_name">potential temperature</att>
+            <att name="time">ocean_time</att>
+            <att name="units">Celsius</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">32.0</att>
+            <att name="colorBarMinimum" type="double">0.0</att>
+            <att name="coordinates">null</att>
+            <att name="standard_name">sea_water_potential_temperature</att>
+            <att name="units">degree_C</att>
+        </addAttributes>
+    </dataVariable>
+</dataset>
+
+<dataset type="EDDGridFromNcFiles" datasetID="model_data_949c_d20a_81a7" active="true">
+    <reloadEveryNMinutes>10080</reloadEveryNMinutes>
+    <updateEveryNMillis>10000</updateEveryNMillis>
+    <fileDir>/erddapData/netcdf/model_data/</fileDir>
+    <fileNameRegex>ngbay_grd_lat_long\.nc</fileNameRegex>
+    <recursive>true</recursive>
+    <pathRegex>.*</pathRegex>
+    <metadataFrom>last</metadataFrom>
+    <matchAxisNDigits>20</matchAxisNDigits>
+    <fileTableInMemory>false</fileTableInMemory>
+    <accessibleViaFiles>false</accessibleViaFiles>
+    <!-- sourceAttributes>
+        <att name="history">GRID file using Matlab script: c_grid, Tuesday - May 3, 2016 - 11:31:28.2636 AM</att>
+        <att name="title">OSOM-coords-lat-long</att>
+        <att name="type">GRID file</att>
+    </sourceAttributes -->
+    <addAttributes>
+        <att name="cdm_data_type">Grid</att>
+        <att name="Conventions">COARDS, CF-1.6, ACDD-1.3</att>
+        <att name="infoUrl">riddc.brown.edu</att>
+        <att name="institution">Rhode Island Data Discovery</att>
+        <att name="keywords">coords, data, eta_rho, latitude, latitute, long, longitude, osom, osom-coords-lat-long, points, rho, rho-points, xi_rho</att>
+        <att name="license">[standard]</att>
+        <att name="standard_name_vocabulary">CF Standard Name Table v55</att>
+        <att name="summary">OSOM-coords-lat-long. Translation from rho coordinates used in OSOM model to latitude and longitude. Data from a local source.</att>
+        <att name="title">OSOM-coords-lat-long</att>
+
+    </addAttributes>
+    <axisVariable>
+        <sourceName>eta_rho</sourceName>
+        <destinationName>eta_rho</destinationName>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">eta rho</att>
+        </addAttributes>
+    </axisVariable>
+    <axisVariable>
+        <sourceName>xi_rho</sourceName>
+        <destinationName>xi_rho</destinationName>
+        <!-- sourceAttributes>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="long_name">xi rho</att>
+        </addAttributes>
+    </axisVariable>
+    <dataVariable>
+        <sourceName>latitude</sourceName>
+        <destinationName>latitude</destinationName>
+        <dataType>double</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="intList">550 500</att>
+            <att name="long_name">latitute of RHO-points</att>
+            <att name="standard_name">latitude</att>
+            <att name="units">degree_north</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">90.0</att>
+            <att name="colorBarMinimum" type="double">-90.0</att>
+            <att name="units">degrees_north</att>
+        </addAttributes>
+    </dataVariable>
+    <dataVariable>
+        <sourceName>longitude</sourceName>
+        <destinationName>longitude</destinationName>
+        <dataType>double</dataType>
+        <!-- sourceAttributes>
+            <att name="_ChunkSizes" type="intList">550 500</att>
+            <att name="long_name">longitude of RHO-points</att>
+            <att name="standard_name">longitude</att>
+            <att name="units">degree_east</att>
+        </sourceAttributes -->
+        <addAttributes>
+            <att name="_ChunkSizes">null</att>
+            <att name="colorBarMaximum" type="double">180.0</att>
+            <att name="colorBarMinimum" type="double">-180.0</att>
+            <att name="units">degrees_east</att>
+        </addAttributes>
+    </dataVariable>
+</dataset>
+
 <dataset type="EDDTableFromMultidimNcFiles" datasetID="model_data_77bb_15c2_6ab3" active="true">
     <reloadEveryNMinutes>10080</reloadEveryNMinutes>
     <updateEveryNMillis>10000</updateEveryNMillis>

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   erddap: &erddap
-    image: axiom/docker-erddap:2.02
+    image: axiom/docker-erddap:2.23-jdk17-openjdk
     ports:
       - 8080:8080
     volumes:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   erddap: &erddap
-    image: axiom/docker-erddap:2.23-jdk17-openjdk
+    image: axiom/docker-erddap:latest-jdk21-openjdk
     ports:
       - 8080:8080
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   erddap: &erddap
-    image: axiom/docker-erddap:2.02
+    image: axiom/docker-erddap:latest-jdk21-openjdk
     environment:
      - TZ=America/New_York
     ports:

--- a/erddap.def
+++ b/erddap.def
@@ -1,13 +1,8 @@
 Bootstrap: docker
 From: axiom/docker-erddap:2.23-jdk17-openjdk
 
-%files
-    ./content/erddap-dev /usr/local/tomcat/content/erddap
-    ./isilon_erddap/erddap_data /erddapData
-    ./config/web.xml /usr/local/tomcat/webapps/erddap/WEB-INF/web.xml
-
 %post
-    # Create any necessary directories that might not exist in the base image
+    # Create necessary directories that might not exist in the base image
     mkdir -p /usr/local/tomcat/content/erddap
     mkdir -p /erddapData
     mkdir -p /usr/local/tomcat/webapps/erddap/WEB-INF

--- a/erddap.def
+++ b/erddap.def
@@ -1,0 +1,30 @@
+Bootstrap: docker
+From: axiom/docker-erddap:2.23-jdk17-openjdk
+
+%files
+    ./content/erddap-dev /usr/local/tomcat/content/erddap
+    ./isilon_erddap/erddap_data /erddapData
+    ./config/web.xml /usr/local/tomcat/webapps/erddap/WEB-INF/web.xml
+
+%post
+    # Create any necessary directories that might not exist in the base image
+    mkdir -p /usr/local/tomcat/content/erddap
+    mkdir -p /erddapData
+    mkdir -p /usr/local/tomcat/webapps/erddap/WEB-INF
+
+%environment
+    export TOMCAT_HOME=/usr/local/tomcat
+    export ERDDAP_DATA=/erddapData
+
+%runscript
+    # This is the default command that will run when the container is executed
+    cd /usr/local/tomcat && catalina.sh run
+
+%apprun erddap
+    cd /usr/local/tomcat && catalina.sh run
+
+%apprun generate_dataset_xml
+    cd /usr/local/tomcat/webapps/erddap/WEB-INF/ && bash GenerateDatasetsXml.sh -verbose
+
+%apprun generate_data_structure
+    cd /usr/local/tomcat/webapps/erddap/WEB-INF/ && bash DasDds.sh -verbose

--- a/erddap.def
+++ b/erddap.def
@@ -1,13 +1,8 @@
 Bootstrap: docker
-From: axiom/docker-erddap:2.23-jdk17-openjdk
-
-%files
-    ./content/erddap-dev /usr/local/tomcat/content/erddap
-    ./isilon_erddap/erddap_data /erddapData
-    ./config/web.xml /usr/local/tomcat/webapps/erddap/WEB-INF/web.xml
+From: axiom/docker-erddap:latest-jdk21-openjdk
 
 %post
-    # Create any necessary directories that might not exist in the base image
+    # Create necessary directories that might not exist in the base image
     mkdir -p /usr/local/tomcat/content/erddap
     mkdir -p /erddapData
     mkdir -p /usr/local/tomcat/webapps/erddap/WEB-INF


### PR DESCRIPTION
This PR adds the OSOM_v2 dataset, which includes years 2005 - 2022. It also adds a Singularity container built from the docker container. For this dataset, it is 1.5 TB, so I had to move it to the `/jobtmp` drive on Oscar and then use the Singularity container to run the dev ERRDAP server, and generate the XML and data structure. 

From what I can tell, the data structure generated all the timepoints we expect. I'm not able to view the dev server in a browser on Oscar, but the math seems to work:

```
105185 timepoints total in the ERDDAP-generated data structure / 18 years / 365 days = 16 timepoints per day

24 hr/day * 60 min/hr = 1440 mins/day
1440 min/day / 90 min intervals = 16 timepoints / day
```

I would like to add this dataset to the production ERDDAP server and fix it from there if need be.